### PR TITLE
Support HTTPS

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@
 'use strict'
 
 const http = require('http')
+const https = require('https')
 const libqp = require('./libqp')
 
 /**
@@ -354,8 +355,9 @@ function injectProperties(result) {
  * @returns {Promise} resolves with JSON or http.IncomingMessage if no body
  */
 function request(options, data) {
+  const client = options.protocol == 'https:' ? https : http
   return new Promise((resolve, reject) => {
-    const req = http
+    const req = client
       .request(options, response => {
         let body = ''
         response


### PR DESCRIPTION
Currently mailhog-node supports only HTTP mailhog API.
If using HTTPS, API access leads to `TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"`.
This patch adds support to HTTPS endpoint.